### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: false
+
+language: perl
+
+perl:
+    - "5.28"
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+install:
+    - cpanm --installdeps .
+    - perl Build.PL
+    - ./Build manifest
+
+script:
+    - ./Build test


### PR DESCRIPTION
This adds a working initial Travis configuration which passes the current test suite on Perls 5.10 .. 5.28.