### PR TITLE
Ignore automatically generated files in git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+Build
+MANIFEST*
+MYMETA.*
+_build/
+blib/
+cover_db/


### PR DESCRIPTION
Now `git status` won't complain about untracked files.