### PR TITLE
Ensure requirements versions match CPAN Meta spec

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -12,9 +12,9 @@ my $build = Module::Build->new(
         Carp => 0,
     },
     build_requires => {
-        'Fennec::Lite'    => "",
-        'Test::More'      => "",
-        'Test::Exception' => "",
+        'Fennec::Lite'    => 0,
+        'Test::More'      => 0,
+        'Test::Exception' => 0,
     },
     meta_merge => {
         resources => {


### PR DESCRIPTION
Setting the versions of the dependencies to the empty string actually
sets an invalid value in this slot in the CPAN Meta specification.  By
using the value '0', we can ensure that any version is acceptable as
intended and match the required spec at the same time.