### PR TITLE
Set minimum Perl version explicitly

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -9,6 +9,7 @@ my $build = Module::Build->new(
     dist_author => 'Chad Granum <exodist7@gmail.com>',
     create_readme => 1,
     requires => {
+        perl => '5.006',
         Carp => 0,
     },
     build_requires => {

--- a/lib/Meta/Builder.pm
+++ b/lib/Meta/Builder.pm
@@ -2,6 +2,7 @@ package Meta::Builder;
 use strict;
 use warnings;
 
+use 5.006;
 use Carp qw/croak/;
 use Meta::Builder::Util;
 use Meta::Builder::Base;


### PR DESCRIPTION
This is current best practice for Perl dists; the version was found via
Perl::MinimumVersion.  Setting this value also helps various automated
build tools to set the Perl version correctly.