### PR TITLE
Quieten Perl::Critic on 'no strict refs'

### DIFF
--- a/lib/Meta/Builder.pm
+++ b/lib/Meta/Builder.pm
@@ -34,7 +34,7 @@ sub import {
     my $caller = caller;
 
     inject( $caller, $_, $class->can( $_ )) for @EXPORT;
-    no strict 'refs';
+    no strict 'refs';  ## no critic
     push @{"$caller\::ISA"} => 'Meta::Builder::Base';
 }
 

--- a/lib/Meta/Builder/Util.pm
+++ b/lib/Meta/Builder/Util.pm
@@ -11,12 +11,12 @@ sub import {
 sub inject {
     my ( $class, $sub, $code, $nowarn ) = @_;
     if ( $nowarn ) {
-        no strict 'refs';
+        no strict 'refs';  ## no critic
         no warnings 'redefine';
         *{"$class\::$sub"} = $code;
     }
     else {
-        no strict 'refs';
+        no strict 'refs';  ## no critic
         *{"$class\::$sub"} = $code;
     }
 }


### PR DESCRIPTION
... since this code actually needs to have the strict refs stricture
disabled and hence Perl::Critic doesn't need to flag this as a problem.