### PR TITLE
Update README to match current main module POD

### DIFF
--- a/README
+++ b/README
@@ -1,21 +1,23 @@
 NAME
+
     Meta::Builder - Tools for creating Meta objects to track custom metrics.
 
 DESCRIPTION
-    Meta programming is becomming more and more popular. The popularity of
+
+    Meta programming is becoming more and more popular. The popularity of
     Meta programming comes from the fact that many problems are made
     significantly easier. There are a few specialized Meta tools out there,
-    for instance <Class:MOP> which is used by Moose to track class metadata.
+    for instance Class:MOP which is used by Moose to track class metadata.
 
-    Meta::Builder is designed to be a generic tool for writing Meta objects.
-    Unlike specialized tools, Meta::Builder makes no assumptions about what
-    metrics you will care about. Meta::Builder also mkaes it simple for
-    others to extend your meta-object based tools by providing hooks for
-    other packages to add metrics to your meta object.
+    Meta::Builder is designed to be a generic tool for writing Meta
+    objects. Unlike specialized tools, Meta::Builder makes no assumptions
+    about what metrics you will care about. Meta::Builder also makes it
+    simple for others to extend your meta-object based tools by providing
+    hooks for other packages to add metrics to your meta object.
 
-    If a specialized Meta object tool is available ot meet your needs please
-    use it. However if you need a simple Meta object to track a couple
-    metrics, use Meta::Builder.
+    If a specialized Meta object tool is available to meet your needs
+    please use it. However if you need a simple Meta object to track a
+    couple metrics, use Meta::Builder.
 
     Meta::Builder is also low-sugar and low-dep. In most cases you will not
     want a class that needs a meta object to use your meta-object class
@@ -23,6 +25,7 @@ DESCRIPTION
     exports enhanced API functions that manipulate the meta object.
 
 SYNOPSIS
+
     My/Meta.pm:
 
         package My::Meta;
@@ -78,48 +81,59 @@ SYNOPSIS
         ...;
 
 USING
+
     When you use Meta::Builder your class is automatically turned into a
     subclass of Meta::Builder::Base. In addition several "sugar" functions
-    are exported into your namespace. To avoid the "sugar" functions you can
-    simply sublass Meta::Builder::Base directly.
+    are exported into your namespace. To avoid the "sugar" functions you
+    can simply subclass Meta::Builder::Base directly.
 
 EXPORTS
+
     metric( $name, \&generator, %actions )
-        Wraper around "caller-"add_metric()>. See Meta::Builder::Base.
+
+      Wraper around caller-add_metric()>. See Meta::Builder::Base.
 
     action( $metric, $name, $code )
-        Wraper around "caller-"add_action()>. See Meta::Builder::Base.
+
+      Wraper around caller-add_action()>. See Meta::Builder::Base.
 
     hash_metric( $name, %additional_actions )
-        Wraper around "caller-"add_hash_metric()>. See Meta::Builder::Base.
+
+      Wraper around caller-add_hash_metric()>. See Meta::Builder::Base.
 
     lists_metric( $name, %additional_actions )
-        Wraper around "caller-"add_lists_metric()>. See Meta::Builder::Base.
+
+      Wraper around caller-add_lists_metric()>. See Meta::Builder::Base.
 
     before( $metric, $action, $code )
-        Wraper around "caller-"hook_before()>. See Meta::Builder::Base.
+
+      Wraper around caller-hook_before()>. See Meta::Builder::Base.
 
     after( $metric, $action, $code )
-        Wraper around "caller-"hook_after()>. See Meta::Builder::Base.
+
+      Wraper around caller-hook_after()>. See Meta::Builder::Base.
 
     accessor( $name )
-        Wraper around "caller-"set_accessor()>. See Meta::Builder::Base.
+
+      Wraper around caller-set_accessor()>. See Meta::Builder::Base.
 
     make_immutable()
-        Overrides all functions/methods that alter the meta objects
-        meta-data. This in effect prevents anything from adding new metrics,
-        actions, or hooks without directly editing the metadata.
+
+      Overrides all functions/methods that alter the meta objects
+      meta-data. This in effect prevents anything from adding new metrics,
+      actions, or hooks without directly editing the metadata.
 
 AUTHORS
+
     Chad Granum exodist7@gmail.com
 
 COPYRIGHT
+
     Copyright (C) 2010 Chad Granum
 
     Meta-Builder is free software; Standard perl licence.
 
     Meta-Builder is distributed in the hope that it will be useful, but
     WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the license for
-    more details.
-
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the license
+    for more details.


### PR DESCRIPTION
Since the docs in the main module's POD has been updated, and because
the README is generated from that source, this change updates the README
to be consistent with the main documentation.